### PR TITLE
Create unique IDs for multiple water heaters

### DIFF
--- a/custom_components/aquanta/binary_sensor.py
+++ b/custom_components/aquanta/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AquantaEntity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import AquantaCoordinator
 
 ENTITY_DESCRIPTIONS = (
@@ -125,6 +125,7 @@ class AquantaBinarySensor(AquantaEntity, BinarySensorEntity):
         self._attr_name = entity_description.name
         self._attr_should_poll = True
         self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
+        LOGGER.debug("Created binary sensor with unique ID %s", self._attr_unique_id)
 
     @property
     def icon(self):

--- a/custom_components/aquanta/binary_sensor.py
+++ b/custom_components/aquanta/binary_sensor.py
@@ -122,6 +122,7 @@ class AquantaBinarySensor(AquantaEntity, BinarySensorEntity):
         super().__init__(coordinator, aquanta_id)
         self.entity_description = entity_description
         self._is_on_func = is_on_func
+        self._attr_name = entity_description.name
         self._attr_should_poll = True
         self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
 

--- a/custom_components/aquanta/binary_sensor.py
+++ b/custom_components/aquanta/binary_sensor.py
@@ -123,7 +123,7 @@ class AquantaBinarySensor(AquantaEntity, BinarySensorEntity):
         self.entity_description = entity_description
         self._is_on_func = is_on_func
         self._attr_should_poll = True
-        self._attr_unique_id += "_" + entity_description.key
+        self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
 
     @property
     def icon(self):

--- a/custom_components/aquanta/binary_sensor.py
+++ b/custom_components/aquanta/binary_sensor.py
@@ -96,14 +96,17 @@ async def async_setup_entry(
     """Initialize Aquanta devices from config entry."""
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    entities: list[AquantaBinarySensor] = []
 
     for aquanta_id in coordinator.data["devices"]:
-        async_add_entities(
-            AquantaBinarySensor(
-                coordinator, aquanta_id, entity_info["desc"], entity_info["is_on"]
+        for entity_info in ENTITY_DESCRIPTIONS:
+            entities.append(
+                AquantaBinarySensor(
+                    coordinator, aquanta_id, entity_info["desc"], entity_info["is_on"]
+                )
             )
-            for entity_info in ENTITY_DESCRIPTIONS
-        )
+
+    async_add_entities(entities)
 
 
 class AquantaBinarySensor(AquantaEntity, BinarySensorEntity):

--- a/custom_components/aquanta/entity.py
+++ b/custom_components/aquanta/entity.py
@@ -23,7 +23,6 @@ class AquantaEntity(CoordinatorEntity):
         self._base_unique_id = f"{coordinator.data['id']}_{aquanta_id}"
         self.aquanta_id = aquanta_id
         self._api = coordinator.aquanta
-        self._attr_unique_id = self._base_unique_id
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -130,7 +130,7 @@ class AquantaSensor(AquantaEntity, SensorEntity):
         self.entity_description: entity_description
         self._native_value_func = native_value_func
         self._attr_should_poll = True
-        self._attr_unique_id += "_" + entity_description.key
+        self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
 
         if entity_description.name is not None:
             self._attr_name = entity_description.name

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -97,18 +97,22 @@ async def async_setup_entry(
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
+    entities: list[AquantaSensor] = []
+
     for aquanta_id in coordinator.data["devices"]:
-        async_add_entities(
-            AquantaSensor(
-                coordinator,
-                aquanta_id,
-                entity_info["desc"],
-                entity_info["native_value"],
-                entity_info["suggested_precision"],
-                entity_info["options"],
+        for entity_info in ENTITY_DESCRIPTIONS:
+            entities.append(
+                AquantaSensor(
+                    coordinator,
+                    aquanta_id,
+                    entity_info["desc"],
+                    entity_info["native_value"],
+                    entity_info["suggested_precision"],
+                    entity_info["options"],
+                )
             )
-            for entity_info in ENTITY_DESCRIPTIONS
-        )
+
+    async_add_entities(entities)
 
 
 class AquantaSensor(AquantaEntity, SensorEntity):

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -115,6 +115,7 @@ class AquantaSensor(AquantaEntity, SensorEntity):
     """Represents a sensor for an Aquanta water heater controller."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = True
 
     def __init__(
         self,
@@ -128,12 +129,9 @@ class AquantaSensor(AquantaEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator, aquanta_id)
         self.entity_description: entity_description
+        self._attr_name = entity_description.name
         self._native_value_func = native_value_func
-        self._attr_should_poll = True
         self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
-
-        if entity_description.name is not None:
-            self._attr_name = entity_description.name
 
         if entity_description.device_class is not None:
             self._attr_device_class = entity_description.device_class

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AquantaEntity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import AquantaCoordinator
 
 ENTITY_DESCRIPTIONS = (
@@ -132,6 +132,7 @@ class AquantaSensor(AquantaEntity, SensorEntity):
         self._attr_name = entity_description.name
         self._native_value_func = native_value_func
         self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
+        LOGGER.debug("Created sensor with unique ID %s", self._attr_unique_id)
 
         if entity_description.device_class is not None:
             self._attr_device_class = entity_description.device_class

--- a/custom_components/aquanta/switch.py
+++ b/custom_components/aquanta/switch.py
@@ -65,6 +65,7 @@ class AquantaSwitch(AquantaEntity, SwitchEntity):
     """Represents a toggle switch for an Aquanta device."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = True
 
     def __init__(
         self,
@@ -81,8 +82,7 @@ class AquantaSwitch(AquantaEntity, SwitchEntity):
         self._is_on_func = is_on_func
         self._async_turn_on_func = async_turn_on_func
         self._async_turn_off_func = async_turn_off_func
-        self._attr_should_poll = True
-        self._attr_unique_id += "_" + entity_description.key
+        self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
 
     @property
     def is_on(self):

--- a/custom_components/aquanta/switch.py
+++ b/custom_components/aquanta/switch.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AquantaEntity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import AquantaCoordinator
 
 ENTITY_DESCRIPTIONS = (
@@ -84,6 +84,7 @@ class AquantaSwitch(AquantaEntity, SwitchEntity):
         self._async_turn_on_func = async_turn_on_func
         self._async_turn_off_func = async_turn_off_func
         self._attr_unique_id = self._base_unique_id + "_" + entity_description.key
+        LOGGER.debug("Created switch with unique ID %s", self._attr_unique_id)
 
     @property
     def is_on(self):

--- a/custom_components/aquanta/switch.py
+++ b/custom_components/aquanta/switch.py
@@ -46,19 +46,22 @@ async def async_setup_entry(
     """Initialize Aquanta devices from config entry."""
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    entities: list[AquantaSwitch] = []
 
     for aquanta_id in coordinator.data["devices"]:
-        async_add_entities(
-            AquantaSwitch(
-                coordinator,
-                aquanta_id,
-                entity_info["desc"],
-                entity_info["is_on"],
-                entity_info["async_turn_on"],
-                entity_info["async_turn_off"],
+        for entity_info in ENTITY_DESCRIPTIONS:
+            entities.append(
+                AquantaSwitch(
+                    coordinator,
+                    aquanta_id,
+                    entity_info["desc"],
+                    entity_info["is_on"],
+                    entity_info["async_turn_on"],
+                    entity_info["async_turn_off"],
+                )
             )
-            for entity_info in ENTITY_DESCRIPTIONS
-        )
+
+    async_add_entities(entities)
 
 
 class AquantaSwitch(AquantaEntity, SwitchEntity):

--- a/custom_components/aquanta/switch.py
+++ b/custom_components/aquanta/switch.py
@@ -79,6 +79,7 @@ class AquantaSwitch(AquantaEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(coordinator, aquanta_id)
         self.entity_description = entity_description
+        self._attr_name = entity_description.name
         self._is_on_func = is_on_func
         self._async_turn_on_func = async_turn_on_func
         self._async_turn_off_func = async_turn_off_func

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -46,6 +46,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     def __init__(self, coordinator, aquanta_id) -> None:
         """Initialize the water heater."""
         super().__init__(coordinator, aquanta_id)
+        self._attr_name = "Water heater"
         self._attr_unique_id = self._base_unique_id + "_water_heater"
 
     @property

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AquantaEntity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 
 
 async def async_setup_entry(
@@ -48,6 +48,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
         super().__init__(coordinator, aquanta_id)
         self._attr_name = "Water heater"
         self._attr_unique_id = self._base_unique_id + "_water_heater"
+        LOGGER.debug("Created water heater with unique ID %s", self._attr_unique_id)
 
     @property
     def current_temperature(self):

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -46,7 +46,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     def __init__(self, coordinator, aquanta_id) -> None:
         """Initialize the water heater."""
         super().__init__(coordinator, aquanta_id)
-        self._attr_unique_id += "_water_heater"
+        self._attr_unique_id = self._base_unique_id + "_water_heater"
 
     @property
     def current_temperature(self):

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -27,12 +27,14 @@ async def async_setup_entry(
     """Initialize Aquanta devices from config entry."""
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    entities: list[AquantaWaterHeater] = []
 
-    async_add_entities(
-        AquantaWaterHeater(coordinator, aquanta_id)
-        for aquanta_id in coordinator.data["devices"]
-    )
+    for aquanta_id in coordinator.data["devices"]:
+        entities.append(
+            AquantaWaterHeater(coordinator, aquanta_id)
+        )
 
+    async_add_entities(entities)
 
 class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     """Representation of an Aquanta water heater controller."""


### PR DESCRIPTION
This PR attempts to fix a bug with multiple water heaters in an account. Further discussion is in issue #12.