### PR TITLE
MAI: Migrate to new unit of measure constant

### DIFF
--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, PERCENTAGE
+from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -23,7 +23,7 @@ ENTITY_DESCRIPTIONS = (
             name="Temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             icon="mdi:water-thermometer",
         ),
         "native_value": lambda entity: entity.coordinator.data["devices"][
@@ -38,7 +38,7 @@ ENTITY_DESCRIPTIONS = (
             name="Set point",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             icon="mdi:thermometer-water",
         ),
         "native_value": lambda entity: entity.coordinator.data["devices"][

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -9,9 +9,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    TEMP_CELSIUS,
-)
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,7 +39,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
 
     _attr_has_entity_name = True
     _attr_supported_features = WaterHeaterEntityFeature.AWAY_MODE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_operation_list = [STATE_ECO, STATE_PERFORMANCE, STATE_OFF]
     _attr_name = "Water heater"
 


### PR DESCRIPTION
Homeassistant Core has deprecated the TEMP_CELSIUS constant.
The new constant is an ENUM which collects all temp units together.

Closes https://github.com/bmcclure/ha-aquanta/issues/66