### PR TITLE
WIP: Reimplement WaterHeaterEntity operation modes to match Aquanta operation modes

### DIFF
--- a/custom_components/aquanta/coordinator.py
+++ b/custom_components/aquanta/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 import async_timeout
 
+from aquanta import Aquanta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
@@ -20,10 +21,10 @@ class AquantaCoordinator(DataUpdateCoordinator):
 
     config_entry: ConfigEntry
 
-    def __init__(self, hass: HomeAssistant, aquanta, account_id) -> None:
+    def __init__(self, hass: HomeAssistant, aquanta: Aquanta, account_id: str) -> None:
         """Initialize the coordinator."""
-        self.aquanta = aquanta
-        self.account_id = account_id
+        self.aquanta: Aquanta = aquanta
+        self.account_id: str = account_id
         super().__init__(
             hass=hass,
             logger=LOGGER,

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -84,6 +85,21 @@ ENTITY_DESCRIPTIONS = (
             "away",
             "off",
         ],
+    },
+    {
+        "desc": SensorEntityDescription(
+            key="efficiency_level",
+            name="Efficiency level",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=PERCENTAGE,
+        ),
+        "native_value": lambda entity: (
+            entity.coordinator.data["devices"][entity.aquanta_id]["advanced"]["efficiencySelection"]
+            * 100
+        ),
+        "suggested_precision": 1,
+        "options": None,
     },
 )
 

--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, PERCENTAGE
+from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -23,7 +23,7 @@ ENTITY_DESCRIPTIONS = (
             name="Temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             icon="mdi:water-thermometer",
         ),
         "native_value": lambda entity: entity.coordinator.data["devices"][
@@ -38,7 +38,7 @@ ENTITY_DESCRIPTIONS = (
             name="Set point",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             icon="mdi:thermometer-water",
         ),
         "native_value": lambda entity: entity.coordinator.data["devices"][

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -9,9 +9,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    TEMP_CELSIUS,
-)
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,7 +39,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
 
     _attr_has_entity_name = True
     _attr_supported_features = WaterHeaterEntityFeature.AWAY_MODE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_operation_list = [STATE_ECO, STATE_PERFORMANCE, STATE_OFF]
     _attr_name = "Water heater"
 

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -91,7 +91,9 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
             ]
         ]
         LOGGER.debug(
-            "Aquanta API reports current mode: {mode} with records of type: {record_types}."
+            "Aquanta API reports current mode: %s with records of type: %s.",
+            mode_type,
+            record_types,
         )
 
         operation: str = STATE_SETPOINT

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -17,10 +17,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .entity import AquantaEntity
 from .const import DOMAIN, LOGGER
 
-STATE_INTELLIGENCE = "aquanta_intelligence"
-STATE_SETPOINT = "setpoint"
-STATE_TIME_OF_USE = "time_of_use"
-STATE_TIMER = "manual_timer"
+STATE_INTELLIGENCE = "Aquanta Intelligence"
+STATE_SETPOINT = "Setpoint"
+STATE_TIME_OF_USE = "Time of Use"
+STATE_TIMER = "Manual Timer"
 # Away is a special state in homeassistant
 
 

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -112,7 +112,7 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
         elif "tou" in record_types:
             operation = STATE_TIME_OF_USE
 
-        LOGGER.debug("The resolved operation mode is {operation}.")
+        LOGGER.debug("The resolved operation mode is %s.", operation)
         return operation
 
     @property

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 from homeassistant.components.water_heater import (
-    STATE_ECO,
-    STATE_PERFORMANCE,
-    STATE_OFF,
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
@@ -51,8 +48,6 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_operation_list: list[str] = [
         STATE_INTELLIGENCE,
-        STATE_OFF,
-        STATE_PERFORMANCE,
         STATE_SETPOINT,
         STATE_TIME_OF_USE,
         STATE_TIMER,
@@ -103,8 +98,6 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
             # controller; it doesn't actually disable the water heater. "Away"
             # is the closest state to "off" that Aquanta can provide.
             operation = STATE_SETPOINT
-        elif mode_type == "boost":
-            operation = STATE_PERFORMANCE
         elif "intel" in record_types:
             operation = STATE_INTELLIGENCE
         elif "timer" in record_types:

--- a/custom_components/aquanta/water_heater.py
+++ b/custom_components/aquanta/water_heater.py
@@ -1,4 +1,5 @@
 """Aquanta water heater component."""
+
 from __future__ import annotations
 
 from homeassistant.components.water_heater import (
@@ -22,6 +23,7 @@ STATE_TIME_OF_USE = "time_of_use"
 STATE_TIMER = "manual_timer"
 # Away is a special state in homeassistant
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -38,6 +40,7 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities)
+
 
 class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     """Representation of an Aquanta water heater controller."""
@@ -76,20 +79,29 @@ class AquantaWaterHeater(AquantaEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str:
         """Return current operation ie. eco, performance, off."""
-        mode_type = self.coordinator.data["devices"][self.aquanta_id]["info"]["currentMode"]["type"]
+        mode_type = self.coordinator.data["devices"][self.aquanta_id]["info"][
+            "currentMode"
+        ]["type"]
         # Since and boost/away modes are special temporary states which preempt
         # other operations states, we need to sometimes look at the records
-        record_types = [record['type'] for record in self.coordinator.data["devices"][self.aquanta_id]["info"]['record']]
-        LOGGER.debug("Aquanta API reports current mode: {mode} with records of type: {record_types}.")
+        record_types = [
+            record["type"]
+            for record in self.coordinator.data["devices"][self.aquanta_id]["info"][
+                "records"
+            ]
+        ]
+        LOGGER.debug(
+            "Aquanta API reports current mode: {mode} with records of type: {record_types}."
+        )
 
         operation: str = STATE_SETPOINT
 
-        if mode_type == 'off':
+        if mode_type == "off":
             # Turning Aquanta "off" actually reverts to the non-smart
             # controller; it doesn't actually disable the water heater. "Away"
             # is the closest state to "off" that Aquanta can provide.
             operation = STATE_SETPOINT
-        elif mode_type == 'boost':
+        elif mode_type == "boost":
             operation = STATE_PERFORMANCE
         elif "intel" in record_types:
             operation = STATE_INTELLIGENCE


### PR DESCRIPTION
The Aquanta controller has 5 operational modes: Aquanta Intelligence, Thermostat Control, Time of Use, Manual Timer, and "Off". Where "Off" just disables the Aquanta controller, so the heater still heats water as if the Aquanta controller was not attached; it is thermostat controlled, just not the Aquanta's thermostat.

This PR reimplements the `WaterHeaterEntity` states to match these four operational states instead of trying to remap them to the states implemented for the generic `WaterHeaterEntity`. This is a step toward being able to use the home assistant interface to switch between these operational modes.