### PR TITLE
DOC: Reduce suggested precision to zero after decimal places

### DIFF
--- a/custom_components/aquanta/sensor.py
+++ b/custom_components/aquanta/sensor.py
@@ -30,7 +30,7 @@ ENTITY_DESCRIPTIONS = (
         "native_value": lambda entity: entity.coordinator.data["devices"][
             entity.aquanta_id
         ]["water"]["temperature"],
-        "suggested_precision": None,
+        "suggested_precision": 0,
         "options": None,
     },
     {
@@ -49,7 +49,7 @@ ENTITY_DESCRIPTIONS = (
             "thermostatEnabled"
         ]
         else None,
-        "suggested_precision": None,
+        "suggested_precision": 0,
         "options": None,
     },
     {
@@ -64,7 +64,7 @@ ENTITY_DESCRIPTIONS = (
             entity.coordinator.data["devices"][entity.aquanta_id]["water"]["available"]
             * 100
         ),
-        "suggested_precision": 1,
+        "suggested_precision": 0,
         "options": None,
     },
     {


### PR DESCRIPTION
Reduce the default precision for temperature sensors and hot water availablility to zero.

When the temperature sensors have `None` suggested precision, you get long numbers when using Farenheit units e.g. "125.0006" due to the conversion from celsius. You really just don't need that many decimal places, so the default precision should be zero. e.g. "125F" or "50C".

Likewise, for available hot water percentage. "84.2%" is too much precision. Can the human mind comprehend 1000 unique states of available hot water? Probably not. I think in this case it would actually be most useful to show liters or gallons of hot water remaining, but the Aquanta API does not report this data, so it should be left to the user to template thier own sensor for this purpose using their knowlege of the capacity of their device.